### PR TITLE
Support request context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - 3.7-dev
 
 install:
+  - pip install "pytest>=3.6"
   - pip install -q pytest-flask
   - pip install -e .
 

--- a/flask_executor/__init__.py
+++ b/flask_executor/__init__.py
@@ -71,12 +71,12 @@ class Executor:
         return _executor(max_workers=executor_max_workers)
 
     def submit(self, fn, *args, **kwargs):
-        if type(self._executor) == concurrent.futures.ThreadPoolExecutor:
+        if isinstance(self._executor, concurrent.futures.ThreadPoolExecutor):
             fn = with_app_context(fn, current_app._get_current_object())
         return self._executor.submit(fn, *args, **kwargs)
 
     def job(self, fn):
-        if type(self._executor) == concurrent.futures.ProcessPoolExecutor:
+        if isinstance(self._executor, concurrent.futures.ProcessPoolExecutor):
             raise TypeError("Can't decorate {}: Executors that use multiprocessing"
                             " don't support decorators".format(fn))
         return ExecutorJob(executor=self, fn=fn)

--- a/flask_executor/__init__.py
+++ b/flask_executor/__init__.py
@@ -1,7 +1,7 @@
 import concurrent.futures
 import sys
 
-from flask import copy_current_request_context
+from flask import copy_current_request_context, current_app
 
 
 __all__ = ('Executor', )

--- a/flask_executor/__init__.py
+++ b/flask_executor/__init__.py
@@ -1,7 +1,7 @@
 import concurrent.futures
 import sys
 
-from flask import current_app
+from flask import copy_current_request_context
 
 
 __all__ = ('Executor', )
@@ -23,13 +23,6 @@ def default_workers(executor_type):
                 return None
         return (cpu_count() or 1) * workers_multiplier[executor_type]
     return None
-
-
-def with_app_context(fn, app):
-    def wrapper(*args, **kwargs):
-        with app.app_context():
-            return fn(*args, **kwargs)
-    return wrapper
 
 
 class ExecutorJob:
@@ -72,7 +65,7 @@ class Executor:
 
     def submit(self, fn, *args, **kwargs):
         if isinstance(self._executor, concurrent.futures.ThreadPoolExecutor):
-            fn = with_app_context(fn, current_app._get_current_object())
+            fn = copy_current_request_context(fn)
         return self._executor.submit(fn, *args, **kwargs)
 
     def job(self, fn):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -2,12 +2,15 @@ import concurrent.futures
 import random
 
 from flask import Flask, current_app, request
-from flask_executor import Executor, ExecutorJob
 import pytest
+
+from flask_executor import Executor, ExecutorJob
 
 
 EXECUTOR_MAX_WORKERS = 10
 
+
+# Reusable functions for tests
 def fib(n):
     if n <= 2:
         return 1
@@ -19,6 +22,9 @@ def app_context_test_value():
 
 def request_context_test_value():
     return request.test_value
+
+
+# Begin tests
 
 def test_init(app):
     executor = Executor(app)
@@ -98,7 +104,7 @@ def test_process_decorator(app):
         assert 0
 
 def test_app_context_thread(app):
-    test_value = random.randint(1,101)
+    test_value = random.randint(1, 101)
     app.config['EXECUTOR_TYPE'] = 'thread'
     app.config['TEST_VALUE'] = test_value
     executor = Executor(app)
@@ -106,7 +112,7 @@ def test_app_context_thread(app):
     assert future.result() == test_value
 
 def test_request_context_thread(app):
-    test_value = random.randint(1,101)
+    test_value = random.randint(1, 101)
     app.config['EXECUTOR_TYPE'] = 'thread'
     executor = Executor(app)
     with app.test_request_context(''):
@@ -115,7 +121,7 @@ def test_request_context_thread(app):
     assert future.result() == test_value
 
 def test_app_context_process(app):
-    test_value = random.randint(1,101)
+    test_value = random.randint(1, 101)
     app.config['EXECUTOR_TYPE'] = 'process'
     app.config['TEST_VALUE'] = test_value
     executor = Executor(app)
@@ -123,7 +129,7 @@ def test_app_context_process(app):
     assert future.result() == test_value
 
 def test_request_context_process(app):
-    test_value = random.randint(1,101)
+    test_value = random.randint(1, 101)
     app.config['EXECUTOR_TYPE'] = 'process'
     executor = Executor(app)
     with app.test_request_context(''):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,6 +1,7 @@
 import concurrent.futures
+import random
 
-from flask import Flask
+from flask import Flask, current_app, request
 from flask_executor import Executor, ExecutorJob
 import pytest
 
@@ -13,6 +14,11 @@ def fib(n):
     else:
         return fib(n-1) + fib(n-2)
 
+def app_context_test_value():
+    return current_app.config['TEST_VALUE']
+
+def request_context_test_value():
+    return request.test_value
 
 def test_init(app):
     executor = Executor(app)
@@ -91,3 +97,36 @@ def test_process_decorator(app):
     else:
         assert 0
 
+def test_app_context_thread(app):
+    test_value = random.randint(1,101)
+    app.config['EXECUTOR_TYPE'] = 'thread'
+    app.config['TEST_VALUE'] = test_value
+    executor = Executor(app)
+    future = executor.submit(app_context_test_value)
+    assert future.result() == test_value
+
+def test_request_context_thread(app):
+    test_value = random.randint(1,101)
+    app.config['EXECUTOR_TYPE'] = 'thread'
+    executor = Executor(app)
+    with app.test_request_context(''):
+        request.test_value = test_value
+        future = executor.submit(request_context_test_value)
+    assert future.result() == test_value
+
+def test_app_context_process(app):
+    test_value = random.randint(1,101)
+    app.config['EXECUTOR_TYPE'] = 'process'
+    app.config['TEST_VALUE'] = test_value
+    executor = Executor(app)
+    future = executor.submit(app_context_test_value)
+    assert future.result() == test_value
+
+def test_request_context_process(app):
+    test_value = random.randint(1,101)
+    app.config['EXECUTOR_TYPE'] = 'process'
+    executor = Executor(app)
+    with app.test_request_context(''):
+        request.test_value = test_value
+        future = executor.submit(request_context_test_value)
+    assert future.result() == test_value


### PR DESCRIPTION
Wraps functions in the request context, not just the app context, to allow functions to work with a copy of the request object and/or the g object. 

Also changes / improves the method of wrapping the application context and uses a more consistent internal API to do so.