### PR TITLE
Exclude tests module from distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url='https://github.com/dchevell/flask-executor',
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests"]),
     keywords=['flask', 'concurrent.futures'],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
I noticed that your package contains a module named `tests`. As long as this module is in distribution, the programmer will not be able to use the same name for own tests. I'm quite sure that's a mistake, due to use `setuptools.find_packages` function, so in this PR I'd suggest excluding the mentioned module.

Also look here: https://setuptools.readthedocs.io/en/latest/setuptools.html#using-find-packages