### PR TITLE
Default done callbacks

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -148,6 +148,21 @@ Flask-Executor lets you decorate methods in the same style as distributed task q
    api/modules
 
 
+Default Callbacks
+-----------------
+
+:class:`concurrent.futures.Future` objects can have callbacks attached by using 
+:meth:`~concurrent.futures.Future.add_done_callback`. Flask-Executor lets you specify default
+callbacks that will be applied to all new futures created by the executor::
+
+    def some_callback(future):
+        # do something with future
+    
+    executor.add_default_done_callback(some_callback)
+
+    # Callback will be added to the below task automatically
+    executor.submit(pow, 323, 1235)
+
 
 Indices and tables
 ==================

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -229,3 +229,13 @@ def test_named_executor_name(default_app):
         assert True
     else:
         assert False
+
+def test_default_done_callback(app):
+    executor = Executor(app)
+    def callback(future):
+        setattr(future, 'test', 'test')
+    executor.add_default_done_callback(callback)
+    with app.test_request_context('/'):
+        future = executor.submit(fib, 5)
+        concurrent.futures.wait([future])
+        assert hasattr(future, 'test')


### PR DESCRIPTION
`concurrent.futures.Future` objects can have callbacks attached by using 
their `add_done_callback` method. This PR adds a new feature, the ability to add default callbacks to the executor which will then be added to the returned Future of every submitted task.

```python
def some_callback(future):
    # do something with future
    
executor.add_default_done_callback(some_callback)

# Callback will be added to the below task automatically
executor.submit(pow, 323, 1235)
```