### PR TITLE
Coerce config types

### DIFF
--- a/flask_executor/executor.py
+++ b/flask_executor/executor.py
@@ -103,8 +103,8 @@ class Executor(concurrent.futures._base.Executor):
         app.config.setdefault(self.EXECUTOR_MAX_WORKERS, executor_max_workers)
         futures_max_length = app.config.setdefault(self.EXECUTOR_FUTURES_MAX_LENGTH, None)
         propagate_exceptions = app.config.setdefault(self.EXECUTOR_PROPAGATE_EXCEPTIONS, False)
-        if futures_max_length:
-            self.futures.max_length = futures_max_length
+        if futures_max_length is not None:
+            self.futures.max_length = int(futures_max_length)
         if propagate_exceptions:
             self.add_default_done_callback(propagate_exceptions_callback)
         self._executor = self._make_executor(app)
@@ -113,6 +113,8 @@ class Executor(concurrent.futures._base.Executor):
     def _make_executor(self, app):
         executor_type = app.config[self.EXECUTOR_TYPE]
         executor_max_workers = app.config[self.EXECUTOR_MAX_WORKERS]
+        if executor_max_workers is not None:
+            executor_max_workers = int(executor_max_workers)
         if executor_type == 'thread':
             _executor = concurrent.futures.ThreadPoolExecutor
         elif executor_type == 'process':

--- a/flask_executor/executor.py
+++ b/flask_executor/executor.py
@@ -35,6 +35,10 @@ def propagate_exceptions_callback(future):
         raise exc
 
 
+def str2bool(v):
+    return str(v).lower() in ("yes", "true", "t", "1")
+
+
 class ExecutorJob:
     """Wraps a function with an executor so to allow the wrapped function to
     submit itself directly to the executor."""
@@ -105,7 +109,7 @@ class Executor(concurrent.futures._base.Executor):
         propagate_exceptions = app.config.setdefault(self.EXECUTOR_PROPAGATE_EXCEPTIONS, False)
         if futures_max_length is not None:
             self.futures.max_length = int(futures_max_length)
-        if propagate_exceptions:
+        if str2bool(propagate_exceptions):
             self.add_default_done_callback(propagate_exceptions_callback)
         self._executor = self._make_executor(app)
         app.extensions[self.name + 'executor'] = self

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -253,3 +253,10 @@ def test_propagate_exception_callback(app):
             concurrent.futures.wait([future])
             assert propagate_exceptions_callback in future._done_callbacks
             propagate_exceptions_callback(future)
+
+def test_coerce_max_workers_value(default_app):
+    default_app.config['EXECUTOR_MAX_WORKERS'] = '5'
+    default_app.config['EXECUTOR_FUTURES_MAX_LENGTH'] = '10'
+    executor = Executor(default_app)
+    with default_app.test_request_context():
+        future = executor.submit_stored('fibonacci', fib, 35)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -254,9 +254,10 @@ def test_propagate_exception_callback(app):
             assert propagate_exceptions_callback in future._done_callbacks
             propagate_exceptions_callback(future)
 
-def test_coerce_max_workers_value(default_app):
+def test_coerce_config_types(default_app):
     default_app.config['EXECUTOR_MAX_WORKERS'] = '5'
     default_app.config['EXECUTOR_FUTURES_MAX_LENGTH'] = '10'
+    default_app.config['EXECUTOR_PROPAGATE_EXCEPTIONS'] = 'true'
     executor = Executor(default_app)
     with default_app.test_request_context():
         future = executor.submit_stored('fibonacci', fib, 35)


### PR DESCRIPTION
Currently if `EXECUTOR_MAX_WORKERS`, `EXECUTOR_ FUTURES_MAX_LENGTH` or `EXECUTOR_PROPAGATE_EXCEPTIONS`  are set to string values (e.g. `EXECUTOR_MAX_WORKERS = '10'`) and not coerced to their expected values (e.g. int or bool) in your config, Flask-Executor mail fail unexpectedly. This is problematic when sourcing config from the environment, where all values are interpreted as strings. 