### PR TITLE
Better proxying

### DIFF
--- a/flask_executor/executor.py
+++ b/flask_executor/executor.py
@@ -8,7 +8,7 @@ from flask import copy_current_request_context
 from flask.globals import _app_ctx_stack
 
 from flask_executor.futures import FutureCollection, FutureProxy
-
+from flask_executor.helpers import InstanceProxy, str2bool
 
 WORKERS_MULTIPLIER = {'thread': 1, 'process': 5}
 
@@ -35,10 +35,6 @@ def propagate_exceptions_callback(future):
         raise exc
 
 
-def str2bool(v):
-    return str(v).lower() in ("yes", "true", "t", "1")
-
-
 class ExecutorJob:
     """Wraps a function with an executor so to allow the wrapped function to
     submit itself directly to the executor."""
@@ -60,7 +56,7 @@ class ExecutorJob:
         return results
 
 
-class Executor(concurrent.futures._base.Executor):
+class Executor(InstanceProxy, concurrent.futures._base.Executor):
     """An executor interface for :py:mod:`concurrent.futures` designed for
     working with Flask applications.
 
@@ -73,7 +69,6 @@ class Executor(concurrent.futures._base.Executor):
 
     def __init__(self, app=None, name=''):
         self.app = app
-        self._executor = None
         self._default_done_callbacks = []
         self.futures = FutureCollection()
         if re.match(r'^(\w+)?$', name) is None:
@@ -89,10 +84,6 @@ class Executor(concurrent.futures._base.Executor):
         self.EXECUTOR_PROPAGATE_EXCEPTIONS = name + 'EXECUTOR_PROPAGATE_EXCEPTIONS'
         if app is not None:
             self.init_app(app)
-
-    def __getattr__(self, attr):
-        # Call any valid Executor method or attribute
-        return getattr(self._executor, attr)
 
     def init_app(self, app):
         """Initialise application. This will also intialise the configured
@@ -111,7 +102,7 @@ class Executor(concurrent.futures._base.Executor):
             self.futures.max_length = int(futures_max_length)
         if str2bool(propagate_exceptions):
             self.add_default_done_callback(propagate_exceptions_callback)
-        self._executor = self._make_executor(app)
+        self._self = self._make_executor(app)
         app.extensions[self.name + 'executor'] = self
 
     def _make_executor(self, app):
@@ -128,7 +119,7 @@ class Executor(concurrent.futures._base.Executor):
         return _executor(max_workers=executor_max_workers)
 
     def _prepare_fn(self, fn, force_copy=False):
-        if isinstance(self._executor, concurrent.futures.ThreadPoolExecutor) \
+        if isinstance(self._self, concurrent.futures.ThreadPoolExecutor) \
             or force_copy:
             fn = copy_current_request_context(fn)
             fn = copy_current_app_context(fn)
@@ -168,7 +159,7 @@ class Executor(concurrent.futures._base.Executor):
         :rtype: flask_executor.FutureProxy
         """
         fn = self._prepare_fn(fn)
-        future = self._executor.submit(fn, *args, **kwargs)
+        future = self._self.submit(fn, *args, **kwargs)
         for callback in self._default_done_callbacks:
             future.add_done_callback(callback)
         return FutureProxy(self, future)
@@ -242,7 +233,7 @@ class Executor(concurrent.futures._base.Executor):
                           method.
         """
         fn = self._prepare_fn(fn)
-        return self._executor.map(fn, *iterables, **kwargs)
+        return self._self.map(fn, *iterables, **kwargs)
 
     def job(self, fn):
         """Decorator. Use this to transform functions into `ExecutorJob`
@@ -260,7 +251,7 @@ class Executor(concurrent.futures._base.Executor):
             future = fib.submit(5)
             results = fib.map(range(1, 6))
         """
-        if isinstance(self._executor, concurrent.futures.ProcessPoolExecutor):
+        if isinstance(self._self, concurrent.futures.ProcessPoolExecutor):
             raise TypeError(
                 "Can't decorate {}: Executors that use multiprocessing "
                 "don't support decorators".format(fn)

--- a/flask_executor/executor.py
+++ b/flask_executor/executor.py
@@ -162,7 +162,7 @@ class Executor(InstanceProxy, concurrent.futures._base.Executor):
         future = self._self.submit(fn, *args, **kwargs)
         for callback in self._default_done_callbacks:
             future.add_done_callback(callback)
-        return FutureProxy(self, future)
+        return FutureProxy(future, self)
 
     def submit_stored(self, future_key, fn, *args, **kwargs):
         """Submits the callable using :meth:`Executor.submit` and stores the

--- a/flask_executor/futures.py
+++ b/flask_executor/futures.py
@@ -1,6 +1,8 @@
 from collections import OrderedDict
 from concurrent.futures import Future
 
+from flask_executor.helpers import InstanceProxy
+
 
 class FutureCollection:
     """A FutureCollection is an object to store and interact with
@@ -78,7 +80,7 @@ class FutureCollection:
         return self._futures.pop(future_key, None)
 
 
-class FutureProxy(Future):
+class FutureProxy(InstanceProxy, Future):
     """A FutureProxy is an instance proxy that wraps an instance of
     :class:`concurrent.futures.Future`. Since an executor can't be made to
     return a subclassed Future object, this proxy class is used to override
@@ -92,12 +94,8 @@ class FutureProxy(Future):
 
     def __init__(self, executor, future):
         self._executor = executor
-        self._future = future
-
-    def __getattr__(self, attr):
-        # Call any valid Future method or attribute
-        return getattr(self._future, attr)
+        self._self = future
 
     def add_done_callback(self, fn):
         fn = self._executor._prepare_fn(fn, force_copy=True)
-        return self._future.add_done_callback(fn)
+        return self._self.add_done_callback(fn)

--- a/flask_executor/futures.py
+++ b/flask_executor/futures.py
@@ -86,15 +86,15 @@ class FutureProxy(InstanceProxy, Future):
     return a subclassed Future object, this proxy class is used to override
     instance behaviours whilst providing an agnostic method of accessing
     the original methods and attributes.
-    :param executor: An instance of :class:`flask_executor.Executor` which
-                     will be used to provide access to Flask context features.
     :param future: An instance of :class:`~concurrent.futures.Future` that
                    the proxy will provide access to.
+    :param executor: An instance of :class:`flask_executor.Executor` which
+                     will be used to provide access to Flask context features.
     """
 
-    def __init__(self, executor, future):
-        self._executor = executor
+    def __init__(self, future, executor):
         self._self = future
+        self._executor = executor
 
     def add_done_callback(self, fn):
         fn = self._executor._prepare_fn(fn, force_copy=True)

--- a/flask_executor/helpers.py
+++ b/flask_executor/helpers.py
@@ -1,0 +1,35 @@
+PROXIED_OBJECT = '__proxied_object'
+
+
+def str2bool(v):
+    return str(v).lower() in ("yes", "true", "t", "1")
+
+
+class InstanceProxy(object):
+
+    def __init__(self, proxied_obj):
+        self._self = proxied_obj
+
+    @property
+    def _self(self):
+        return object.__getattribute__(self, PROXIED_OBJECT)
+
+    @_self.setter
+    def _self(self, proxied_obj):
+        object.__setattr__(self, PROXIED_OBJECT, proxied_obj)
+        return self
+
+    def __getattribute__(self, attr):
+        super_cls_dict = InstanceProxy.__dict__
+        cls_dict = object.__getattribute__(self, '__class__').__dict__
+        inst_dict = object.__getattribute__(self, '__dict__')
+        if attr in cls_dict or attr in inst_dict or attr in super_cls_dict:
+            return object.__getattribute__(self, attr)
+        target_obj = object.__getattribute__(self, PROXIED_OBJECT)
+        return object.__getattribute__(target_obj, attr)
+
+    def __repr__(self):
+        class_name =  object.__getattribute__(self, '__class__').__name__
+        target_repr = repr(self._self)
+        return '<%s( %s )>' % (class_name, target_repr)
+

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -35,28 +35,30 @@ def test_init(app):
     executor = Executor(app)
     assert 'executor' in app.extensions
     assert isinstance(executor, concurrent.futures._base.Executor)
-    assert isinstance(executor._executor, concurrent.futures._base.Executor)
-    assert executor.__getattr__('shutdown')
+    assert isinstance(executor._self, concurrent.futures._base.Executor)
+    assert getattr(executor, 'shutdown')
 
 def test_factory_init(app):
     executor = Executor()
     executor.init_app(app)
     assert 'executor' in app.extensions
-    assert isinstance(executor._executor, concurrent.futures._base.Executor)
+    assert isinstance(executor._self, concurrent.futures._base.Executor)
 
 def test_thread_executor_init(default_app):
     default_app.config['EXECUTOR_TYPE'] = 'thread'
     executor = Executor(default_app)
-    assert isinstance(executor._executor, concurrent.futures.ThreadPoolExecutor)
+    assert isinstance(executor._self, concurrent.futures.ThreadPoolExecutor)
+    assert isinstance(executor, concurrent.futures.ThreadPoolExecutor)
 
 def test_process_executor_init(default_app):
     default_app.config['EXECUTOR_TYPE'] = 'process'
     executor = Executor(default_app)
-    assert isinstance(executor._executor, concurrent.futures.ProcessPoolExecutor)
+    assert isinstance(executor._self, concurrent.futures.ProcessPoolExecutor)
+    assert isinstance(executor, concurrent.futures.ProcessPoolExecutor)
 
 def test_default_executor_init(default_app):
     executor = Executor(default_app)
-    assert isinstance(executor._executor, concurrent.futures.ThreadPoolExecutor)
+    assert isinstance(executor._self, concurrent.futures.ThreadPoolExecutor)
 
 def test_invalid_executor_init(default_app):
     default_app.config['EXECUTOR_TYPE'] = 'invalid_value'
@@ -87,7 +89,7 @@ def test_max_workers(app):
     EXECUTOR_MAX_WORKERS = 10
     app.config['EXECUTOR_MAX_WORKERS'] = EXECUTOR_MAX_WORKERS
     executor = Executor(app)
-    assert executor._executor._max_workers == EXECUTOR_MAX_WORKERS
+    assert executor._self._max_workers == EXECUTOR_MAX_WORKERS
 
 def test_thread_decorator_submit(default_app):
     default_app.config['EXECUTOR_TYPE'] = 'thread'
@@ -215,8 +217,8 @@ def test_named_executor(default_app):
     custom_executor = Executor(default_app, name=name)
     assert 'executor' in default_app.extensions
     assert name + 'executor' in default_app.extensions
-    assert executor._executor._max_workers == EXECUTOR_MAX_WORKERS
-    assert custom_executor._executor._max_workers == CUSTOM_EXECUTOR_MAX_WORKERS
+    assert executor._self._max_workers == EXECUTOR_MAX_WORKERS
+    assert custom_executor._self._max_workers == CUSTOM_EXECUTOR_MAX_WORKERS
 
 def test_named_executor_submit(app):
     name = 'custom'
@@ -261,3 +263,9 @@ def test_coerce_config_types(default_app):
     executor = Executor(default_app)
     with default_app.test_request_context():
         future = executor.submit_stored('fibonacci', fib, 35)
+
+def test_shutdown_executor(default_app):
+    executor = Executor(default_app)
+    assert executor._shutdown is False
+    executor.shutdown()
+    assert executor._shutdown is True

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -89,6 +89,7 @@ def test_max_workers(app):
     EXECUTOR_MAX_WORKERS = 10
     app.config['EXECUTOR_MAX_WORKERS'] = EXECUTOR_MAX_WORKERS
     executor = Executor(app)
+    assert executor._max_workers == EXECUTOR_MAX_WORKERS
     assert executor._self._max_workers == EXECUTOR_MAX_WORKERS
 
 def test_thread_decorator_submit(default_app):
@@ -218,7 +219,9 @@ def test_named_executor(default_app):
     assert 'executor' in default_app.extensions
     assert name + 'executor' in default_app.extensions
     assert executor._self._max_workers == EXECUTOR_MAX_WORKERS
+    assert executor._max_workers == EXECUTOR_MAX_WORKERS
     assert custom_executor._self._max_workers == CUSTOM_EXECUTOR_MAX_WORKERS
+    assert custom_executor._max_workers == CUSTOM_EXECUTOR_MAX_WORKERS
 
 def test_named_executor_submit(app):
     name = 'custom'

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -5,6 +5,7 @@ import pytest
 
 from flask_executor import Executor
 from flask_executor.futures import FutureCollection, FutureProxy
+from flask_executor.helpers import InstanceProxy
 
 
 def fib(n):
@@ -85,3 +86,12 @@ def test_add_done_callback(default_app):
         future.add_done_callback(callback)
     concurrent.futures.wait([future])
     assert exception is None
+
+def test_instance_proxy():
+    class TestProxy(InstanceProxy):
+        pass
+    x = TestProxy(concurrent.futures.Future())
+    assert isinstance(x, concurrent.futures.Future)
+    assert 'TestProxy' in repr(x)
+    assert 'Future' in repr(x)
+


### PR DESCRIPTION
`Executor` and `FutureProxy` classes have specialised behaviour to proxy attribute and method calls to the objects that they wrap (a behaviour required when subclassing is not practical). This updates that behaviour to be more robust.